### PR TITLE
Scaffold VitePress site with Bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # website
-TMS main marketing site
+
+TMS main marketing site built with [VitePress](https://vitepress.dev) and [Bun](https://bun.sh).
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+bun install
+bun run dev
+```
+
+Build for production:
+
+```bash
+bun run build
+```

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitepress'
+import theme from '@lando/vitepress-theme-default-plus'
+
+export default defineConfig({
+  extends: theme,
+  lang: 'en-US',
+  title: 'TMS Website',
+  description: 'Main marketing site',
+})

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Welcome to TMS
+
+This site is powered by **VitePress** running with **Bun**.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "website",
+  "private": true,
+  "packageManager": "bun@1.2.14",
+  "scripts": {
+    "dev": "bunx vitepress dev docs",
+    "build": "bunx vitepress build docs",
+    "serve": "bunx vitepress serve docs"
+  },
+  "devDependencies": {
+    "vitepress": "^1.0.0",
+    "@lando/vitepress-theme-default-plus": "latest"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold docs directory for VitePress
- use Bun scripts and add `@lando/vitepress-theme-default-plus`
- update README with development instructions

## Testing
- `bun install` *(fails: 403 Forbidden)*
- `bun run build` *(fails: GET https://registry.npmjs.org/vitepress - 403)*

------
https://chatgpt.com/codex/tasks/task_e_6883d120607c83218097578fe5c05532